### PR TITLE
Force matching text of mention to exist before adding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Batch of helpful formatters and patterns
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.1.0"
+    rev: "v4.2.0"
     hooks:
       - id: check-json
       - id: check-yaml
@@ -18,7 +18,7 @@ repos:
 
   # Adds a standard feel to import segments
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.0.1
+    rev: v3.1.0
     hooks:
       - id: reorder-python-imports
         args: [--py3-plus]
@@ -44,6 +44,6 @@ repos:
 
   # Type enforcement for Python
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.950
     hooks:
       - id: mypy

--- a/src/cardmaker/webhookcard.py
+++ b/src/cardmaker/webhookcard.py
@@ -62,5 +62,15 @@ class WebhookCard:
         self.body.append(element)
 
     def add_mention(self, mention: Mention) -> None:
-        """Include a mention in the card. Does not check if `text` is referenced."""
+        """Include a mention in the card."""
+        is_referenced = False
+        for element in self.body:
+            if hasattr(element, "text") and mention.text in element.text:  # type: ignore # noqa: E501
+                is_referenced = True
+                break
+        if not is_referenced:
+            raise ValueError(
+                f"Mention text '{mention.text}' referenced before defined in "
+                "an element. Elements containing the mention text must be added first."
+            )
         self.entities.append(mention)

--- a/tests/webhookcard_test.py
+++ b/tests/webhookcard_test.py
@@ -67,8 +67,22 @@ def test_empty_card_asdict(hookcard: WebhookCard) -> None:
     assert hookcard.asdict() == EMPTY_WEBHOOK_CARD
 
 
-def test_add_mention(hookcard: WebhookCard) -> None:
-    mention = hookcard.new_mention("mock", "123", "mock")
+def test_raise_on_mention_with_no_matching_text(hookcard: WebhookCard) -> None:
+    hookcard.add_element(hookcard.new_image(**TEST_IMAGE))
+    hookcard.add_element(hookcard.new_textblock(**TEST_TEXTBLOCK))
+    mention = hookcard.new_mention("<at>Bob</at>", "123", "mock")
+
+    with pytest.raises(ValueError):
+        hookcard.add_mention(mention)
+
+    assert True
+
+
+def test_no_raise_on_mention_with_matching_text(hookcard: WebhookCard) -> None:
+    hookcard.add_element(hookcard.new_image(**TEST_IMAGE))
+    hookcard.add_element(hookcard.new_textblock(**TEST_TEXTBLOCK))
+    hookcard.add_element(hookcard.new_textblock("Hi, <at>Bob</at>"))
+    mention = hookcard.new_mention("<at>Bob</at>", "123", "mock")
 
     hookcard.add_mention(mention)
 


### PR DESCRIPTION
If a mention that does not have a matching `text` in the card's elements
is added, the MSTeams api will accept the payload. However, no card will
be rendered. To avoid this confusion, raise if a mention is added before
its `text` exists in an element.

closes #2 